### PR TITLE
fix: node 18 network interfaces support

### DIFF
--- a/utils/Tools.js
+++ b/utils/Tools.js
@@ -50,7 +50,7 @@ class Tools {
         const IPs = Tools
             .GET_NETWORK_INTERFACES()
             .filter(i => {
-                return i.family === "IPv4";
+                return i.family === "IPv4" || i.family === 4;
             })
             .map(i => {
                 return i.address;


### PR DESCRIPTION
While I was running the bridge on the latest version of node I did not get any interfaces to show up in the output. 
It seems like I ran in the same issue as described here.
https://github.com/nodejs/node/issues/42787

I added a simple else to keep backwards compatiblity.