### PR TITLE
Add build for MacOS arm64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,6 @@
                 'name': 'Build',
                 'run': 'npm run build',
               },
-
               {
                 'name': 'Upload win x64',
                 'uses': 'actions/upload-release-asset@v1.0.2',
@@ -54,6 +53,18 @@
                     'upload_url': '${{ github.event.release.upload_url }}',
                     'asset_path': './build/valetudo-helper-httpbridge-armv7',
                     'asset_name': 'valetudo-helper-httpbridge-armv7',
+                    'asset_content_type': 'binary/octet-stream',
+                  },
+              },
+              {
+                'name': 'Upload mac arm64',
+                'uses': 'actions/upload-release-asset@v1.0.2',
+                'env': { 'GITHUB_TOKEN': '${{ secrets.GITHUB_TOKEN }}' },
+                'with':
+                  {
+                    'upload_url': '${{ github.event.release.upload_url }}',
+                    'asset_path': './build/valetudo-helper-httpbridge-mac-arm64',
+                    'asset_name': 'valetudo-helper-httpbridge-mac-arm64',
                     'asset_content_type': 'binary/octet-stream',
                   },
               },

--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
   "bin": "app.js",
   "scripts": {
     "start": "node app.js",
-
-    "build": "npm run build_win && npm run build_lin_amd64 && npm run build_lin_armv7",
+    "build": "npm run build_win && npm run build_lin_amd64 && npm run build_lin_armv7 && npm run build_mac_arm64",
     "build_win": "cross-env PKG_CACHE_PATH=./build_dependencies/pkg pkg --targets node16-win-x64 --compress Brotli --no-bytecode --public-packages \"*\" . --output ./build/valetudo-helper-httpbridge.exe",
     "build_lin_amd64": "cross-env PKG_CACHE_PATH=./build_dependencies/pkg pkg --targets node16-linuxstatic-x64 --compress Brotli --no-bytecode --public-packages \"*\" . --output ./build/valetudo-helper-httpbridge-amd64",
-    "build_lin_armv7": "cross-env PKG_CACHE_PATH=./build_dependencies/pkg pkg --targets node16-linuxstatic-armv7 --compress Brotli --no-bytecode --public-packages \"*\" . --output ./build/valetudo-helper-httpbridge-armv7"
+    "build_lin_armv7": "cross-env PKG_CACHE_PATH=./build_dependencies/pkg pkg --targets node16-linuxstatic-armv7 --compress Brotli --no-bytecode --public-packages \"*\" . --output ./build/valetudo-helper-httpbridge-armv7",
+    "build_mac_arm64": "cross-env PKG_CACHE_PATH=./build_dependencies/pkg pkg --targets node16-macos-arm64 --compress Brotli --no-bytecode --public-packages \"*\" . --output ./build/valetudo-helper-httpbridge-mac-arm64"
   },
   "author": "",
   "license": "Apache-2.0",
@@ -21,7 +21,7 @@
     "serve-index": "^1.9.1"
   },
   "devDependencies": {
-    "cross-env": "7.0.3",
+    "cross-env": "^7.0.3",
     "pkg": "5.6.0"
   }
 }


### PR DESCRIPTION
Tested and confirmed on MacBook Pro M1 running MacOS 13.2.1.

```zsh
❯ uname -vm
Darwin Kernel Version 22.3.0: Mon Jan 30 20:38:37 PST 2023; root:xnu-8792.81.3~2/RELEASE_ARM64_T6000 arm64
❯ ./valetudo-helper-httpbridge-mac-arm64
Starting valetudo-helper-httpbridge
Note that uploads will happily overwrite existing files. Please be careful


valetudo-helper-httpbridge started successfully.
It is serving "/Users/mark/git/valetudo-helper-httpbridge/build/www" via:


http://192.168.xx.xx:55815/
Download example:	wget http://192.168.xx.xx:55815/file.tar
Upload example:		curl -X POST http://192.168.xx.xx:55815/upload -F 'file=@./file.tar'
File listing is also available


^C
```